### PR TITLE
Use AppleScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.DS_Store

--- a/lib/md2key/applescripts/activate_last_slide.applescript
+++ b/lib/md2key/applescripts/activate_last_slide.applescript
@@ -1,0 +1,9 @@
+on run argv
+	tell application "Keynote"
+		activate
+		set TEMPLATE_SLIDE_INDEX to 2
+		tell the front document
+			move slide TEMPLATE_SLIDE_INDEX to before slide TEMPLATE_SLIDE_INDEX
+		end tell
+	end tell
+end run

--- a/lib/md2key/applescripts/create_slide.applescript
+++ b/lib/md2key/applescripts/create_slide.applescript
@@ -1,0 +1,19 @@
+-- First argument - title
+-- Second arument - content
+on run argv
+	tell application "Keynote"
+		tell the front document
+			-- Workaround to select correct master slide. In spite of master slide can be selected by name,
+			-- name property is not limited to be unique.
+			-- So move the focus to second slide and force "make new slide" to use the exact master slide.
+			set TEMPLATE_SLIDE_INDEX to 2
+			move slide TEMPLATE_SLIDE_INDEX to before slide TEMPLATE_SLIDE_INDEX
+
+			set newSlide to make new slide
+			tell newSlide
+				set object text of default title item to first item of argv
+				set object text of default body item to second item of argv
+			end tell
+		end tell
+	end tell
+end run

--- a/lib/md2key/applescripts/delete_extra_slides.applescript
+++ b/lib/md2key/applescripts/delete_extra_slides.applescript
@@ -1,0 +1,15 @@
+-- First argument - slides count
+on run argv
+	tell application "Keynote"
+		set theSlides to slides of the front document
+		set n to first item of argv as number
+
+		repeat with theSlide in theSlides
+			if n > 2 then
+				delete slide n of the front document
+			end if
+
+			set n to n - 1
+		end repeat
+	end tell
+end run

--- a/lib/md2key/applescripts/delete_template_slide.applescript
+++ b/lib/md2key/applescripts/delete_template_slide.applescript
@@ -1,0 +1,6 @@
+tell application "Keynote"
+	set TEMPLATE_SLIDE_INDEX to 2
+	          tell the front document
+            delete slide TEMPLATE_SLIDE_INDEX
+          end tell
+end tell

--- a/lib/md2key/applescripts/ensure_template_slide_availability.applescript
+++ b/lib/md2key/applescripts/ensure_template_slide_availability.applescript
@@ -1,0 +1,5 @@
+tell application "Keynote"
+          tell the front document
+            make new slide
+          end
+end tell

--- a/lib/md2key/applescripts/insert_code_background.applescript
+++ b/lib/md2key/applescripts/insert_code_background.applescript
@@ -1,0 +1,16 @@
+-- First argument - slides count
+-- Second argument - code background path
+on run argv
+	tell application "Keynote"
+		tell the front document
+			set theSlide to slide first item of argv
+			set theImage to POSIX file second item of argv
+			set docWidth to its width
+			set docHeight to its height
+			
+			tell theSlide
+				make new image with properties {opacity:80, file:theImage, width:docWidth - 180, position:{90, 240}}
+			end tell
+		end tell
+	end tell
+end run

--- a/lib/md2key/applescripts/insert_image.applescript
+++ b/lib/md2key/applescripts/insert_image.applescript
@@ -1,0 +1,28 @@
+-- First argument - slides count
+-- Second argument - POSIX path
+on run argv
+	tell application "Keynote"
+		tell the front document
+			set TEMPLATE_SLIDE_INDEX to 2
+
+			set slideNumber to first item of argv as number
+			set theSlide to slide slideNumber
+			set theImage to second item of argv as POSIX file
+			set docWidth to its width
+			set docHeight to its height
+
+ 			-- Create temporary slide to fix the image size
+			tell slide TEMPLATE_SLIDE_INDEX
+				set imgFile to make new image with properties { file:theImage, width:docWidth / 3 }
+				tell imgFile
+					set imgWidth to its width
+					set imgHeight to its width
+				end tell
+			end tell
+
+			tell theSlide
+				make new image with properties {file:theImage, width:imgWidth, position:{ docWidth - imgWidth - 60, docHeight / 2 - imgHeight / 2 } }
+			end tell
+		end tell
+	end tell
+end run

--- a/lib/md2key/applescripts/paste_clipboard.applescript
+++ b/lib/md2key/applescripts/paste_clipboard.applescript
@@ -1,0 +1,7 @@
+          tell application "Keynote"
+            tell application "System Events"
+              tell application process "Keynote"
+                keystroke "v" using { command down }
+              end tell
+            end tell
+          end tell

--- a/lib/md2key/applescripts/slides_count.applescript
+++ b/lib/md2key/applescripts/slides_count.applescript
@@ -1,0 +1,8 @@
+tell application "Keynote"
+	set n to 0
+	set theSlides to slides of the front document
+	repeat with theSlide in theSlides
+		set n to n + 1
+	end repeat
+	do shell script "echo " & n
+end tell

--- a/lib/md2key/applescripts/update_cover.applescript
+++ b/lib/md2key/applescripts/update_cover.applescript
@@ -1,0 +1,14 @@
+-- First argument - title
+-- Second argument - sub
+on run argv
+	tell application "Keynote"
+		set COVER_SLIDE_INDEX to 1
+
+		tell the front document
+			tell slide COVER_SLIDE_INDEX
+				set object text of default title item to first item of argv
+				set object text of default body item to second item of argv
+			end tell
+		end tell
+	end tell
+end run

--- a/lib/md2key/converter.rb
+++ b/lib/md2key/converter.rb
@@ -25,9 +25,9 @@ module Md2key
     end
 
     def generate_contents
-      Keynote.update_cover(@markdown.cover.title, @markdown.cover.lines.join('\n'))
+      Keynote.update_cover(@markdown.cover.title, @markdown.cover.lines.join("\n"))
       @markdown.slides.each_with_index do |slide, index|
-        Keynote.create_slide(slide.title, slide.lines.join('\n'))
+        Keynote.create_slide(slide.title, slide.lines.join("\n"))
         Keynote.insert_image(slide.image) if slide.image
         Keynote.insert_code(slide.code) if slide.code
       end

--- a/lib/md2key/keynote.rb
+++ b/lib/md2key/keynote.rb
@@ -13,7 +13,7 @@ module Md2key
       def ensure_template_slide_availability
         return if slides_count >= 2
         execute_applescript(:void, :ensure_template_slide_availability)
-      en
+      end
 
       # All slides after a second slide are unnecessary and deleted.
       def delete_extra_slides

--- a/lib/md2key/keynote.rb
+++ b/lib/md2key/keynote.rb
@@ -2,97 +2,35 @@ require 'unindent'
 
 module Md2key
   class Keynote
-    COVER_SLIDE_INDEX    = 1
-    TEMPLATE_SLIDE_INDEX = 2
     CODE_BACKGROUND_PATH = File.expand_path('../../assets/background.png', __dir__)
 
     class << self
       # You must provide a first slide as a cover slide.
       def update_cover(title, sub)
-        tell_keynote(<<-APPLE.unindent)
-          tell the front document
-            tell slide #{COVER_SLIDE_INDEX}
-              set object text of default title item to "#{title}"
-              set object text of default body item to "#{sub}"
-            end tell
-          end tell
-        APPLE
+        execute_applescript(:void, :update_cover, title, sub)
       end
 
       def ensure_template_slide_availability
         return if slides_count >= 2
-
-        tell_keynote(<<-APPLE.unindent)
-          tell the front document
-            make new slide
-          end
-        APPLE
-      end
+        execute_applescript(:void, :ensure_template_slide_availability)
+      en
 
       # All slides after a second slide are unnecessary and deleted.
       def delete_extra_slides
-        tell_keynote(<<-APPLE.unindent)
-          set theSlides to slides of the front document
-          set n to #{slides_count}
-
-          repeat with theSlide in theSlides
-            if n > 2 then
-              delete slide n of the front document
-            end if
-
-            set n to n - 1
-          end repeat
-        APPLE
+        execute_applescript(:void, :delete_extra_slides, slides_count)
       end
 
       def delete_template_slide
-        tell_keynote(<<-APPLE.unindent)
-          tell the front document
-            delete slide #{TEMPLATE_SLIDE_INDEX}
-          end tell
-        APPLE
+        execute_applescript(:void, :delete_template_slide)
       end
 
       def create_slide(title, content)
-        tell_keynote(<<-APPLE.unindent)
-          tell the front document
-            -- Workaround to select correct master slide. In spite of master slide can be selected by name,
-            -- name property is not limited to be unique.
-            -- So move the focus to second slide and force "make new slide" to use the exact master slide.
-            #{move_to_slide(TEMPLATE_SLIDE_INDEX)}
-
-            set newSlide to make new slide
-            tell newSlide
-              set object text of default title item to "#{title}"
-              set object text of default body item to "#{content}"
-            end tell
-          end tell
-        APPLE
+        execute_applescript(:void, :create_slide, title, content)
       end
 
       # Insert image to the last slide
       def insert_image(path)
-        tell_keynote(<<-APPLE.unindent)
-          tell the front document
-            set theSlide to slide #{slides_count}
-            set theImage to POSIX file "#{path}"
-            set docWidth to its width
-            set docHeight to its height
-
-            -- Create temporary slide to fix the image size
-            tell slide #{TEMPLATE_SLIDE_INDEX}
-              set imgFile to make new image with properties { file: theImage, width: docWidth / 3 }
-              tell imgFile
-                set imgWidth to its width
-                set imgHeight to its width
-              end tell
-            end tell
-
-            tell theSlide
-              make new image with properties { file: theImage, width: imgWidth, position: { docWidth - imgWidth - 60, docHeight / 2 - imgHeight / 2 } }
-            end tell
-          end tell
-        APPLE
+        execute_applescript(:void, :insert_image, path)
       end
 
       def insert_code(code)
@@ -105,76 +43,34 @@ module Md2key
       private
 
       def insert_code_background
-        tell_keynote(<<-APPLE.unindent)
-          tell the front document
-            set theSlide to slide #{slides_count}
-            set theImage to POSIX file "#{CODE_BACKGROUND_PATH}"
-            set docWidth to its width
-            set docHeight to its height
-
-            tell theSlide
-              make new image with properties { opacity: 80, file: theImage, width: docWidth - 180, position: { 90, 240 } }
-            end tell
-          end tell
-        APPLE
+        execute_applescript(:void, :insert_code_background, slides_count, CODE_BACKGROUND_PATH)
       end
 
       def activate_last_slide
-        tell_keynote(<<-APPLE.unindent)
-          activate
-
-          tell the front document
-            #{move_to_slide(slides_count)}
-          end tell
-        APPLE
-      end
-
-      # Workaround to activate the slide of given index. `show slide [index]`
-      # didn't work...
-      def move_to_slide(index)
-        "move slide #{index} to before slide #{index}"
+        execute_applescript(:void, :activate_last_slide)
       end
 
       def paste_clipboard
-        execute_applescript(<<-APPLE.unindent)
-          tell application "Keynote"
-            tell application "System Events"
-              tell application process "Keynote"
-                keystroke "v" using { command down }
-              end tell
-            end tell
-          end tell
-        APPLE
+        execute_applescript(:void, :paste_clipboard)
       end
 
       def slides_count
-        tell_keynote(<<-APPLE.unindent).to_i
-          set n to 0
-          set theSlides to slides of the front document
-          repeat with theSlide in theSlides
-            set n to n + 1
-          end repeat
-          do shell script "echo " & n
-        APPLE
+        execute_applescript(:int, :slides_count)
       end
 
-      def tell_keynote(script)
-        lines = [
-          'tell application "Keynote"',
-          *script.split("\n"),
-          'end tell',
-        ]
-        execute_applescript(lines.join("\n"))
+      def execute_applescript(type, script_name, *args)
+        path = script_path(script_name.to_s)
+        args.map! { |arg|  "\"#{arg}\"" }
+        command = "osascript #{path} #{args.join(' ')}"
+        `#{command + ' > /dev/null'}` if type == :void
+        `#{command}}`.to_i if type == :int
       end
 
-      def execute_applescript(script)
-        file = Tempfile.new('applescript')
-        file.write(script)
-        file.close
-        `osascript #{file.path}`.strip
-      ensure
-        file.delete
+      def script_path(script_name)
+        applescripts_path = File.expand_path('/applescripts', __dir__)
+        File.join(applescripts_path, "#{script_name}.applescript")
       end
+
     end
   end
 end

--- a/lib/md2key/keynote.rb
+++ b/lib/md2key/keynote.rb
@@ -67,7 +67,7 @@ module Md2key
       end
 
       def script_path(script_name)
-        applescripts_path = File.expand_path('/applescripts', __dir__)
+        applescripts_path = File.expand_path('applescripts', __dir__)
         File.join(applescripts_path, "#{script_name}.applescript")
       end
 


### PR DESCRIPTION
Move AppleScript logic to separate AppleScript files:
* Reduce code (convenient to read Keynote class now)
* Improve performance (remove operations with creating new applescript files; remove code which create huge strings with AppleScript code)
