### PR TITLE
Add installation to README and fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 # v0.4.0
 
-- Support sintax-highlighted source code insert
+- Support syntax-highlighted source code insert
 
 # v0.3.3
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 Convert your markdown to keynote.
 
+## Installation
+
+`gem install md2key`
+
 ## Usage
 
 - 1. Create a keynote document
 - 2. Create a first slide as a cover slide
 - 3. Create a second slide to choose a slide layout
-- 4. Then execute `gem install md2key && md2key markdown.md`
+- 4. Then execute `md2key markdown.md`
 
 ![](https://i.gyazo.com/9d4d00164683f516d44b3e536b3dd3e9.gif)
 


### PR DESCRIPTION
* Add installation. I think it's more convenient
Also, `fish` shell doesn't support `&&`:
![2015-08-09 17 32 31](https://cloud.githubusercontent.com/assets/13235519/9154873/b961a314-3ebc-11e5-8dfb-02660ac4c7de.png)

* Fix typo in Changelog

