### PR TITLE
convert img src in markdown to full pass to support relative file path

### DIFF
--- a/lib/md2key/keynote.rb
+++ b/lib/md2key/keynote.rb
@@ -30,7 +30,7 @@ module Md2key
 
       # Insert image to the last slide
       def insert_image(path)
-        execute_applescript('insert_image', slides_count, path, TEMPLATE_SLIDE_INDEX)
+        execute_applescript('insert_image', slides_count, File.absolute_path(path), TEMPLATE_SLIDE_INDEX)
       end
 
       def insert_code(code)


### PR DESCRIPTION
Now it can support both

```
![](/Users/liubin/Desktop/xxx.png)
```
and
```
![](./images/yyy.png)
```
