### PR TITLE
set default file extension for <pre> syntax without specifying filetype

### DIFF
--- a/lib/md2key/highlight.rb
+++ b/lib/md2key/highlight.rb
@@ -1,10 +1,13 @@
 module Md2key
   class Highlight
+    DEFAULT_EXTENSION = "txt"
     class << self
       def pbcopy_highlighted_code(code)
         ensure_highlight_availability
 
-        file = Tempfile.new(["code", ".#{code.extension}"])
+        extension = code.extension || DEFAULT_EXTENSION
+
+        file = Tempfile.new(["code", ".#{extension}"])
         file.write(code.source)
         file.close
 

--- a/lib/md2key/markdown.rb
+++ b/lib/md2key/markdown.rb
@@ -59,7 +59,8 @@ module Md2key
         when 'pre'
           node.children.each do |child|
             next if !child.is_a?(Oga::XML::Element) || child.name != 'code'
-            slide.code = Code.new(child.text, child.attribute('class').value)
+            extension = child.attribute('class') ? child.attribute('class').value : nil
+            slide.code = Code.new(child.text, extension)
           end
         when 'hr'
           # noop


### PR DESCRIPTION
If I use `<pre>` syntax without filetype specifier, it raises `NoMethodError`.

For example,

<pre>
$ cat exception_pre.md

## some title

BAD

```
Here is
inside
pre syntax
```

OK

```rb
puts "this goes good"
```

$md2key exception_pre.md
/usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/lib/md2key/markdown.rb:62:in `block (2 levels) in generate_slides': undefined method `value' for nil:NilClass (NoMethodError)
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/oga-1.2.3/lib/oga/xml/node_set.rb:62:in `block in each'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/oga-1.2.3/lib/oga/xml/node_set.rb:62:in `each'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/oga-1.2.3/lib/oga/xml/node_set.rb:62:in `each'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/lib/md2key/markdown.rb:60:in `block in generate_slides'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/oga-1.2.3/lib/oga/xml/node_set.rb:62:in `block in each'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/oga-1.2.3/lib/oga/xml/node_set.rb:62:in `each'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/oga-1.2.3/lib/oga/xml/node_set.rb:62:in `each'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/lib/md2key/markdown.rb:33:in `generate_slides'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/lib/md2key/markdown.rb:26:in `cached_slides'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/lib/md2key/markdown.rb:16:in `cover'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/lib/md2key/converter.rb:28:in `generate_contents'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/lib/md2key/converter.rb:15:in `generate_keynote!'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/lib/md2key/converter.rb:6:in `convert_markdown'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/lib/md2key/cli.rb:7:in `convert'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/lib/md2key/cli.rb:19:in `default_task'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/lib/md2key/cli.rb:15:in `method_missing'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:29:in `run'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:126:in `run'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/md2key-0.4.3/bin/md2key:6:in `<top (required)>'
        from /usr/local/var/rbenv/versions/2.1.5/bin/md2key:23:in `load'
        from /usr/local/var/rbenv/versions/2.1.5/bin/md2key:23:in `<main>'

</pre>

For prevent this error, I'd like to set default filetype `.txt` which is used if there are `<pre>` syntax without specifying filetype. 

Thanks.