### PR TITLE
Initial implementation of presenter notes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ end
 ```
 </pre>
 
+### Insert presenter note
+
+```markdown
+# Keynote Speech
+
+- OMG! I'm keynoting! :fearful:
+
+^ Remember, what would Freddie Mercury do? Yes, I'm Freddie! We are the champions!!
+```
+
 ## License
 
 MIT License

--- a/lib/md2key/converter.rb
+++ b/lib/md2key/converter.rb
@@ -35,6 +35,7 @@ module Md2key
           Keynote.insert_image(slide.image) if slide.image
           Keynote.insert_code(slide.code) if slide.code
         end
+        Keynote.insert_note(slide.note) if slide.note
       end
     end
   end

--- a/lib/md2key/keynote.rb
+++ b/lib/md2key/keynote.rb
@@ -84,6 +84,11 @@ module Md2key
         end
       end
 
+      # Insert presenter note
+      def insert_note(note)
+        execute_applescript('insert_note', slides_count, note)
+      end
+
       private
 
       def insert_code_background

--- a/lib/md2key/markdown.rb
+++ b/lib/md2key/markdown.rb
@@ -85,6 +85,9 @@ module Md2key
             if child.is_a?(Oga::XML::Element) && child.name == 'img'
               slide.image = child.attribute('src').value
               next
+            elsif child.is_a?(Oga::XML::Text) && child.text.start_with?('^ ')
+              slide.note = child.text.sub(/^\^ /, '')
+              next
             end
             slide.lines << Line.new(child.text)
           end

--- a/lib/md2key/slide.rb
+++ b/lib/md2key/slide.rb
@@ -1,5 +1,5 @@
 module Md2key
-  class Slide < Struct.new(:title, :lines, :image, :code, :table)
+  class Slide < Struct.new(:title, :lines, :image, :code, :table, :note)
     def initialize(*)
       super
       self.lines ||= []

--- a/scripts/insert_note.scpt
+++ b/scripts/insert_note.scpt
@@ -1,0 +1,12 @@
+on run argv
+  set lastIndex     to item 1 of argv as number
+  set theNote    to item 2 of argv
+
+  tell application "Keynote"
+    tell the front document
+      tell slide lastIndex
+        set presenter notes to theNote
+      end tell
+    end tell
+  end tell
+end run


### PR DESCRIPTION
Added a presenter notes support.

I chose the [Deckset compatible syntax](http://www.decksetapp.com/cheatsheet/#presenter-notes), id est:
- if there's a paragraph that starts with a `^ `
- put the whole paragraph to the presenter note of the current slide
- don't show the text on the slides

I'm aware that the implementation is sort of adhoc, probably we'd better add another filter-like preprocessor or post-processor layer around the Markdown conversion, then maybe we could switch to another Markdown parser that supports Markdown comment (I don't know if there's any).
But for now, I believe my version would be a not-bad start as a smallest possible patch that works. :)

Note that the weird README phrase is taken from https://twitter.com/josevalim/status/194763352969457664

closes #18