### PR TITLE
Allow passing negative integer to osascript

### DIFF
--- a/lib/md2key/keynote.rb
+++ b/lib/md2key/keynote.rb
@@ -147,7 +147,11 @@ module Md2key
       def execute_applescript(script_name, *args)
         path = script_path(script_name)
         script = ERB.new(File.read(path)).result
-        IO.popen(['osascript', '-e', script, *args.map(&:to_s)], &:read)
+        IO.popen(['osascript', '-', *args.map(&:to_s)], 'r+') do |io|
+          io.write(script)
+          io.close_write
+          io.read
+        end
       end
 
       def script_path(script_name)


### PR DESCRIPTION
I met an following error:

```
$ md2key sample.md
osascript: illegal option -- 1
usage: osascript [-l language] [-e script] [-i] [-s {ehso}] [programfile] [argument ...]
```

So I prefer `osascript -` rather than `osascript -e '...'`