### PR TITLE
Automatically associate master slide with special names

### DIFF
--- a/lib/md2key/configuration.rb
+++ b/lib/md2key/configuration.rb
@@ -21,6 +21,7 @@ module Md2key
       validate!
     end
 
+    # @return [String,nil]
     def cover_master
       master = @masters.find do |master|
         master.cover
@@ -28,6 +29,8 @@ module Md2key
       master && master.name
     end
 
+    # @param [Integer] level
+    # @return [String,nil]
     def slide_master(level)
       master = @masters.find do |master|
         master.template == level

--- a/lib/md2key/keynote.rb
+++ b/lib/md2key/keynote.rb
@@ -91,10 +91,13 @@ module Md2key
         execute_applescript('insert_note', slides_count, note)
       end
 
+      # @param [Integer] slide_index
+      # @return [String]
       def fetch_master_slide_name(slide_index)
         execute_applescript('fetch_master_slide_name', slide_index).rstrip
       end
 
+      # @return [Array<String>]
       def fetch_master_slide_names
         execute_applescript('fetch_master_slide_names').strip.split("\n")
       end

--- a/lib/md2key/renderer.rb
+++ b/lib/md2key/renderer.rb
@@ -3,6 +3,10 @@ require 'md2key/keynote'
 
 module Md2key
   class Renderer
+    # Magic number index for master slide named "cover"
+    COVER_LEVEL = 0
+
+    # @param [Md2key::Configuration] config
     def initialize(config)
       @config = config
     end
@@ -22,22 +26,45 @@ module Md2key
       Keynote.delete_extra_slides
     end
 
+    # @param [Md2key::Nodes::Presentation] ast
     def generate_contents(ast)
-      cover_master = Keynote.fetch_master_slide_name(1)
-      main_master  = Keynote.fetch_master_slide_name(2)
+      first_master    = Keynote.fetch_master_slide_name(1)
+      second_master   = Keynote.fetch_master_slide_name(2)
+      master_by_level = fetch_master_by_level
 
-      Keynote.update_cover(ast.cover, @config.cover_master || cover_master)
+      cover_master = @config.cover_master || master_by_level.fetch(COVER_LEVEL, first_master)
+      Keynote.update_cover(ast.cover, cover_master)
+
       ast.slides.each do |slide|
-        master = @config.slide_master(slide.level) || main_master
+        slide_master = @config.slide_master(slide.level) || master_by_level.fetch(slide.level, second_master)
+
         if slide.table
-          Keynote.create_slide_with_table(slide, slide.table.rows, slide.table.columns, master)
+          Keynote.create_slide_with_table(slide, slide.table.rows, slide.table.columns, slide_master)
           Keynote.insert_table(slide.table.data)
         else
-          Keynote.create_slide(slide, master)
+          Keynote.create_slide(slide, slide_master)
           Keynote.insert_image(slide.image) if slide.image
           Keynote.insert_code(slide.code) if slide.code
         end
+
         Keynote.insert_note(slide.note) if slide.note
+      end
+    end
+
+    # Find master names like "h1", "h2", ... and return { 1 => "h1", 2 => "h2" } only for available ones.
+    # @return [Hash{ Integer => String }]
+    def fetch_master_by_level
+      masters = Keynote.fetch_master_slide_names
+
+      {}.tap do |result|
+        masters.each do |master|
+          if master.match(/\Ah(?<level>[1-5])\z/)
+            level = Integer(Regexp.last_match[:level])
+            result[level] = master
+          elsif master == 'cover'
+            result[COVER_LEVEL] = 'cover'
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Another interface of md2key
In addition to current interface, the new way to specify master slides is added.

When you name master slides as "cover", "h1", "h2", "h3", "h4" or "h5", md2key will use the master slides for the first slide, slides with `#`, `##`, `###`, `####` or `#####`.

## Demo
![md2key](https://user-images.githubusercontent.com/3138447/33668109-2221dc98-dae2-11e7-9c56-a4c57cd158b9.gif)

### example.md

```md
# The cover
"cover" is used

# Header 1: "h1" is used

## Header 2
- "h2" is used

### Header 3
- "h3".

## Header 2 again
- "h2".
```