### PR TITLE
Update CI environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,23 +9,22 @@ jobs:
 
       matrix:
         os:
-         - macos-10.15
-         - macos-11.0
+         - macos-14
+         - macos-15
 
         ruby-version:
-          - '2.3'
-          - '2.4'
-          - '2.5'
           - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
+          - '3.4'
           - ruby-head
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
- Added Ruby 3.3 and 3.4
- Drop Ruby < 2.6 because macos-14 and 15 don't support them
- Switched os to macos-14 and macos-15, which are currently available on GitHub Actions (ref: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/)
- Upgraded actions/checkout to the latest v5